### PR TITLE
DOC: more explicit testing instructions.

### DIFF
--- a/docs/source/developer/testing.rst
+++ b/docs/source/developer/testing.rst
@@ -1,7 +1,13 @@
 Testing
 =======
 
-Testing is done with the `unittest` framework. In the parent directory,
+Testing is done with the `unittest` framework. In the parent directory, build the source files
+
+.. code-block:: bash
+
+   $ python setup.py build_src build_ext --inplace
+
+and run the testing utility
 
 .. code-block:: bash
 


### PR DESCRIPTION
It only took me a couple months to completely forget what I had done previously and that before running the `nose`, one must first build the source files. So I added that explicitly in the testing instructions...